### PR TITLE
Sprint3 james test - fix urls so root redirects to index

### DIFF
--- a/mhapsite/mhapsite/urls.py
+++ b/mhapsite/mhapsite/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
+from django.shortcuts import redirect
 from mhap import views as mhapviews
 from axes.decorators import watch_login
 #https://simpleisbetterthancomplex.com/tutorial/2016/09/19/how-to-create-password-reset-view.html
@@ -39,4 +40,5 @@ urlpatterns = [
         auth_views.password_reset_confirm, name='password_reset_confirm'),
     url(r'^reset/done/$', auth_views.password_reset_complete, name='password_reset_complete'),
     url(r'^captcha/', include('captcha.urls')),
+    url(r'^', lambda r: redirect('mhap/')),
 ]


### PR DESCRIPTION
Root url now redirects to index (mhap homepage). As far as I can tell, this works without messing up anything else.